### PR TITLE
Add Gitleaks secret scanning workflow, Makefile target, and SECURITY_BUILD documentation

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,30 @@
+name: Secret scanning
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PRODUCT_VERSION ?= 0.0.0
 BUILD_NUMBER ?= 0
 BUILD_CHANNEL ?= nightly
 ONLYOFFICE_VALUE ?= onlyoffice
+GITLEAKS_IMAGE ?= ghcr.io/gitleaks/gitleaks:latest
 
 COMPANY_NAME_LOW = $(shell echo $(COMPANY_NAME) | tr A-Z a-z)
 DOCKERFILE := $(if $(PRODUCT_EDITION),Dockerfile.enterprise,Dockerfile)
@@ -25,7 +26,7 @@ DOCKER_IMAGE := $(DOCKER_ORG)/4testing-$(PRODUCT_NAME)$(PRODUCT_EDITION)
 DOCKER_DUMMY := $(COMPANY_NAME_LOW)-$(PRODUCT_NAME)$(PRODUCT_EDITION)__$(DOCKER_TAG).dummy
 DOCKER_ARCH := $(COMPANY_NAME_LOW)-$(PRODUCT_NAME)_$(DOCKER_TAG).tar.gz
 
-.PHONY: all clean clean-docker image deploy docker
+.PHONY: all clean clean-docker image deploy docker secret-scan
 
 $(DOCKER_DUMMY):
 	docker build -f $(DOCKERFILE) \
@@ -64,3 +65,6 @@ ifeq ($(BUILD_CHANNEL),nightly)
 		docker push $(DOCKER_IMAGE):latest && break || sleep 1m; \
 	done
 endif
+
+secret-scan:
+	docker run --rm -v "$$(pwd):/repo:ro" $(GITLEAKS_IMAGE) detect --source /repo --verbose

--- a/SECURITY_BUILD.md
+++ b/SECURITY_BUILD.md
@@ -1,0 +1,30 @@
+# Build security checks
+
+This repository runs secret scanning as the first DevSecOps control for the Docker image build workflow.
+
+## Secret scanning
+
+Secret scanning is implemented with Gitleaks in GitHub Actions. The workflow scans pull requests, pushes to the main development branches, weekly scheduled runs, and manual dispatches.
+
+The workflow intentionally checks out the full Git history (`fetch-depth: 0`) so Gitleaks can detect secrets that may have been introduced in earlier commits, not only in the tip of a branch.
+
+## Local usage
+
+Run the same scanner locally before opening a pull request:
+
+```bash
+make secret-scan
+```
+
+The Makefile target uses the official Gitleaks container image and mounts the repository read-only into the scanner container.
+
+## Handling findings
+
+If Gitleaks reports a secret:
+
+1. Remove the secret from the repository.
+2. Rotate the exposed credential in the upstream service.
+3. Re-run `make secret-scan`.
+4. If the finding is a false positive, document why before adding an allowlist rule.
+
+Do not commit real JWT secrets, TLS private keys, database passwords, API tokens, or cloud credentials. Example configuration values should use placeholders such as `<replace-with-secure-random-value>`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     # Uncomment to enable JWT validation:
     #environment:
     #  - JWT_ENABLED=true
-    #  - JWT_SECRET=secret
+    #  - JWT_SECRET=<replace-with-secure-random-value>
     #  - JWT_HEADER=Authorization
     #  - JWT_IN_BODY=true
     ports:


### PR DESCRIPTION
### Motivation

- Introduce first-line secret scanning to detect leaked credentials in the repository history and during CI runs.
- Provide a local developer workflow to run the same scanner before opening pull requests.

### Description

- Add GitHub Actions workflow `/.github/workflows/secret-scan.yml` to run Gitleaks on `pull_request`, pushes to `master` and `develop`, manual dispatch, and a weekly schedule, and checkout full history with `fetch-depth: 0`.
- Add `GITLEAKS_IMAGE` variable, mark `secret-scan` in `.PHONY`, and add `secret-scan` Makefile target that runs the official Gitleaks container against the repository.
- Add `SECURITY_BUILD.md` documenting the secret scanning setup, local usage via `make secret-scan`, and guidance for handling findings.
- Update `docker-compose.yml` example to replace an inline example secret with a placeholder `JWT_SECRET=<replace-with-secure-random-value>`.

### Testing

- No automated tests were executed as part of this change; the new workflow will run Gitleaks automatically on pull requests, pushes to configured branches, scheduled runs, and manual dispatches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50f152741c8327ac148eaaccea1362)