### PR TITLE
Add Trivy image scan workflow and trigger for DocumentServer images

### DIFF
--- a/.github/workflows/4testing-build.yml
+++ b/.github/workflows/4testing-build.yml
@@ -194,6 +194,25 @@ jobs:
                  -f version="${VERSION}"
         shell: bash
 
+      # Run Trivy scans for community and developer images from release/hotfix branches.
+      - name: Trigger Trivy scan
+        if: >-
+             (matrix.edition == 'community' || matrix.edition == 'developer') &&
+             matrix.platform == 'amd64' &&
+             (startsWith(steps.build-ds.outputs.branch, 'release/') ||
+              startsWith(steps.build-ds.outputs.branch, 'hotfix/'))
+        env:
+          VERSION: ${{ steps.build-ds.outputs.version }}
+          EDITION: ${{ matrix.edition }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+            gh workflow run trivy-ds.yml \
+                 --repo "${REPO}" \
+                 -f edition="${EDITION}" \
+                 -f version="${VERSION}"
+        shell: bash
+
       - name: Save build result to file
         if: always()
         run: |

--- a/.github/workflows/trivy-ds.yml
+++ b/.github/workflows/trivy-ds.yml
@@ -1,0 +1,60 @@
+---
+name: Scan DocumentServer image with Trivy
+
+run-name: >-
+  Trivy scan for ${{ github.event.inputs.edition }} DocumentServer image version: ${{ github.event.inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'DocumentServer image version to scan'
+        type: string
+        required: true
+      edition:
+        description: 'DocumentServer edition to scan'
+        type: choice
+        options:
+          - community
+          - developer
+        required: true
+
+env:
+  TAG: ${{ github.event.inputs.version }}
+  EDITION_SUFFIX: ${{ github.event.inputs.edition == 'developer' && '-de' || '' }}
+
+jobs:
+  trivy:
+    name: Scan DocumentServer image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create directory for scan results
+        run: mkdir -p trivy-results
+
+      - name: Scan image vulnerabilities
+        # Check CVEs.
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: onlyoffice/4testing-documentserver${{ env.EDITION_SUFFIX }}:${{ env.TAG }}
+          format: table
+          output: trivy-results/vulnerabilities.txt
+          scanners: vuln
+          exit-code: '0'
+
+      - name: Scan image secrets
+        # Check keys, tokens, and passwords.
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: onlyoffice/4testing-documentserver${{ env.EDITION_SUFFIX }}:${{ env.TAG }}
+          format: table
+          output: trivy-results/secrets.txt
+          scanners: secret
+          exit-code: '0'
+
+      - name: Upload Trivy scan results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-results-${{ github.event.inputs.edition }}-${{ env.TAG }}
+          path: trivy-results
+          if-no-files-found: warn


### PR DESCRIPTION
### Motivation
- Add automated Trivy vulnerability and secret scans for DocumentServer images built for release and hotfix branches for the `community` and `developer` editions. 

### Description
- Add new workflow `./github/workflows/trivy-ds.yml` that runs `aquasecurity/trivy-action@0.33.1` to scan `onlyoffice/4testing-documentserver` images for vulnerabilities and secrets and uploads results as artifacts. 
- Update `./github/workflows/4testing-build.yml` to trigger `trivy-ds.yml` for `community` and `developer` editions on `release/*` and `hotfix/*` branches, passing `edition` and `version`. 
- Emit scan outputs to `trivy-results/vulnerabilities.txt` and `trivy-results/secrets.txt` and upload as `trivy-results-${{ github.event.inputs.edition }}-${{ env.TAG }}` artifact. 
- Configure scans to use `exit-code: '0'` so scan findings do not fail the parent build job and restrict triggering to the `amd64` matrix. 

### Testing
- No automated unit tests were modified or executed as part of this change. 
- The added workflows are YAML-only and will be exercised by GitHub Actions when the `workflow_dispatch` is invoked or when the trigger conditions in `4testing-build.yml` are met.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d2d8309ec832790a2726b8355be8f)